### PR TITLE
Enable the user to change the mappings (eg. if <Space> is already used)

### DIFF
--- a/doc/space.txt
+++ b/doc/space.txt
@@ -16,21 +16,24 @@
 
                                                                  *space-toc*
 
-1. Intro                                               |space-intro|
-2. Usage                                               |space-usage|
-3. Hooks                                               |space-hooks|
-4. Status line integration                             |space-statusline|
-5. Configuration                                       |space-configuration|
-6. License                                             |space-license|
+1. Intro                                       |space-intro|
+2. Usage                                       |space-usage|
+3. Hooks                                       |space-hooks|
+4. Status line integration                     |space-statusline|
+5. Configuration                               |space-configuration|
+    5.1 User-defined mappings                          |space-conf-mapping|
+    5.2 Navigation group restriction                   |space-conf-navgroup|
+    5.3 Miscellaneous configuration                    |space-conf-misc|
+6. License                                     |space-license|
 
 
 
 ==============================================================================
 1. Intro                                                       *space-intro*
 
-space.vim is a plugin which remaps the *<Space>* key to act as a clever key
-to repeat motions. To disable space.vim, set the "space_loaded" global
-variable in your |vimrc| file: >
+space.vim is a plugin which remaps the *<Space>* key (or any other key, see
+|space-conf-mapping|) to act as a clever key to repeat motions. To disable
+space.vim, set the "space_loaded" global variable in your |vimrc| file: >
     :let g:space_loaded = 1
 
 space.vim hooks into several of the more complex motion commands, such as
@@ -201,6 +204,38 @@ status line using the GetSpaceMovement() function. Here's an example: >
 ==============================================================================
 5. Configuration                                       *space-configuration*
 
+
+5.1 User-defined mappings                               *space-conf-mapping* 
+
+It is possible to use another key than <Space> if you wish to. Just map
+another key to the right <plug> reference as shown below.
+
+Note: Be careful when choosing your mapping to not interfere with space.vim
+features. For example, by default, Vim maps <Tab> (ie. <C-i>) to "newer
+position in jump list" (see :h <tab>), which is actually something that
+space.vim can repeat by default. Hence, if you want to use the <Tab> key with
+space.vim, you need to disable "space_jump".
+
+
+
+Map <F1> instead of <Space> to jump to the next item: >
+    nmap <unique> <F1> <Plug>SmartspaceNext
+
+Map <Tab> instead of <S-Space> to jump to the previous item. Also disable
+space jump feature to avoid issues (see the note above): >
+    nmap <unique> <Tab> <Plug>SmartspacePrev
+    let g:space_no_jump = 1
+
+Map ; instead of <BS> to jump to the previous item (second mapping only for
+non-GUI, initially created to avoid <S-Space> terminal capability issues): >
+    nmap <unique> ; <Plug>SmartspacePrevnongui
+
+If you do not wish to use <Plug>SmartspacePrevnongui, use the following: >
+    let g:space_no_second_prev_mapping = 1            
+
+
+5.2 Navigation group restriction                       *space-conf-navgroup*
+
 It is possible to avoid using the <Space> key for groups of navigation
 commands using global variables. For instance, you may wish to use <Space> to
 repeat the last command only for diff jumps and quickfix and location list
@@ -238,6 +273,9 @@ Disable <Space> for quickfix and location list commands >
 
 Disable <Space> for undolist movements >
     let g:space_no_undolist = 1
+
+
+5.3 Miscellaneous configuration                            *space-conf-misc*
 
 Furthermore it is possible to disable the hooks and mappings set by space.vim
 to affect the select mode (these can cause problems with some snippets plugins

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -106,14 +106,14 @@ if !hasmapto('<Plug>SmartspaceNext')
     if mapcheck("<Space>") == ""
         nmap <unique> <Space> <Plug>SmartspaceNext
     else
-        echo "space.vim: <Space> key already mapped. Please map another key to <Plug>SmartspaceNext."
+        echomsg "space.vim: <Space> key already mapped. Please map another key to <Plug>SmartspaceNext."
     endif
 endif
 if !hasmapto('<Plug>SmartspacePrev')
     if mapcheck("<S-Space>") == ""
         nmap <unique> <S-Space> <Plug>SmartspacePrev
     else
-        echo "space.vim: <S-Space> key already mapped. Please map another key to <Plug>SmartspacePrev."
+        echomsg "space.vim: <S-Space> key already mapped. Please map another key to <Plug>SmartspacePrev."
     endif
 endif
 noremap <script> <expr> <silent> <Plug>SmartspaceNext <SID>do_space(0, v:char)
@@ -130,7 +130,7 @@ if !has("gui_running") && !g:space_no_second_prev_mapping
         if mapcheck("<BS>") == ""
             nmap <unique> <BS> <Plug>SmartspacePrevnogui
         else
-            echo "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui."
+            echomsg "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui."
         endif
     endif
     noremap <expr> <silent> <Plug>SmartspacePrevnogui <SID>do_space(1, v:char)

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -578,7 +578,8 @@ function! s:do_space(shift, default)
 endfunc
 
 function! s:maybe_open_fold(cmd)
-    if !exists("g:space_no_foldopen") && &foldopen =~ s:cmd_type && v:operator != "c"
+    if !exists("g:space_no_foldopen") && &foldopen =~ s:cmd_type &&
+                \ exists("v:operator") && v:operator != "c"
         " special treatment of :ex commands
         if s:cmd_type == "quickfix" || s:cmd_type == "tag"
             if getcmdtype() == ':'

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -70,8 +70,7 @@
 "   endfunc
 "   set statusline+=%{SlSpace()}
 
-" TODO: Make the mapping assignments more dynamical, and allow user defined
-"       commands?
+" TODO: Allow user defined commands?
 
 if exists("g:space_debug")
     let g:space_no_character_movements = 0
@@ -85,26 +84,59 @@ if exists("g:space_debug")
     let g:space_no_quickfix = 0
     let g:space_no_undolist = 0
     let g:space_no_tags = 0
+    let g:space_disable_select_mode = 0
+    let g:space_no_second_prev_mapping = 0
     echomsg "Running space.vim in debug mode."
 elseif exists("g:space_loaded")
     finish
 endif
 let g:space_loaded = 1
 
-" Mapping of <Space>/<S-Space> and possibly <BS>
-noremap <expr> <silent> <Space>   <SID>do_space(0, "<Space>")
-noremap <expr> <silent> <S-Space> <SID>do_space(1, "<S-Space>")
-
-if exists("g:space_disable_select_mode")
-    silent! sunmap <Space>
-    silent! sunmap <S-Space>
-    silent! sunmap <BS>
+" Initialise default config vars values properly to avoid
+" using '!exists("g:space_foo") || !g:space_foo'
+if !exists("g:space_disable_select_mode")
+    let g:space_disable_select_mode = 0
+endif
+if !exists("g:space_no_second_prev_mapping")
+    let g:space_no_second_prev_mapping = 0
 endif
 
-if mapcheck("<BS>") == "" || !has("gui_running")
-    noremap <expr> <silent> <BS>      <SID>do_space(1, "<BS>")
-    if exists("g:space_disable_select_mode")
-        silent! sunmap <BS>
+" Mapping of <Space>/<S-Space> and possibly <BS>
+if !hasmapto('<Plug>SmartspaceNext')
+    if mapcheck("<Space>") == ""
+        nmap <unique> <Space> <Plug>SmartspaceNext
+    else
+        echo "space.vim: <Space> key already mapped. Please map another key to <Plug>SmartspaceNext."
+    endif
+endif
+if !hasmapto('<Plug>SmartspacePrev')
+    if mapcheck("<S-Space>") == ""
+        nmap <unique> <S-Space> <Plug>SmartspacePrev
+    else
+        echo "space.vim: <S-Space> key already mapped. Please map another key to <Plug>SmartspacePrev."
+    endif
+endif
+noremap <script> <expr> <silent> <Plug>SmartspaceNext <SID>do_space(0, v:char)
+noremap <script> <expr> <silent> <Plug>SmartspacePrev <SID>do_space(1, v:char)
+
+if g:space_disable_select_mode
+    silent! sunmap <Plug>SmartspaceNext
+    silent! sunmap <Plug>SmartspacePrev
+endif
+
+" Backspace is only for console
+if !has("gui_running") && !g:space_no_second_prev_mapping
+    if !hasmapto('<Plug>SmartspacePrevnogui')
+        if mapcheck("<BS>") == ""
+            nmap <unique> <BS> <Plug>SmartspacePrevnogui
+        else
+            echo "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui."
+        endif
+    endif
+    noremap <expr> <silent> <Plug>SmartspacePrevnogui <SID>do_space(1, v:char)
+
+    if g:space_disable_select_mode
+        silent! sunmap <Plug>SmartspacePrevnogui
     endif
 endif
 
@@ -118,7 +150,7 @@ if !exists("g:space_no_character_movements") || !g:space_no_character_movements
     noremap <expr> <silent> ; <SID>setup_space("char", ";")
     noremap <expr> <silent> , <SID>setup_space("char", ",")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap f
         silent! sunmap F
         silent! sunmap t
@@ -155,7 +187,7 @@ if !exists("g:space_no_search") || !g:space_no_search
     noremap <expr> <silent> n  <SID>setup_space("search", "n")
     noremap <expr> <silent> N  <SID>setup_space("search", "N")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap *
         silent! sunmap #
         silent! sunmap <kMultiply>
@@ -184,7 +216,7 @@ if !exists("g:space_no_diff") || !g:space_no_diff
     noremap <expr> <silent> ]c <SID>setup_space("diff", "]c")
     noremap <expr> <silent> [c <SID>setup_space("diff", "[c")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]c
         silent! sunmap [c
     endif
@@ -198,7 +230,7 @@ if !exists("g:space_no_brace") || !g:space_no_brace
     noremap <expr> <silent> ]} <SID>setup_space("curly", "]}")
     noremap <expr> <silent> [{ <SID>setup_space("curly", "[{")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ])
         silent! sunmap [(
         silent! sunmap ]}
@@ -214,7 +246,7 @@ if !exists("g:space_no_method") || !g:space_no_method
     noremap <expr> <silent> ]M <SID>setup_space("method_end", "]M")
     noremap <expr> <silent> [M <SID>setup_space("method_end", "[M")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]m
         silent! sunmap [m
         silent! sunmap ]M
@@ -230,7 +262,7 @@ if !exists("g:space_no_section") || !g:space_no_section
     noremap <expr> <silent> ][ <SID>setup_space("section_end", "][")
     noremap <expr> <silent> [] <SID>setup_space("section_end", "[]")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]]
         silent! sunmap [[
         silent! sunmap ][
@@ -246,7 +278,7 @@ if !exists("g:space_no_folds") || !g:space_no_folds
     noremap <expr> <silent> ]z <SID>setup_space("fold_start", "]z")
     noremap <expr> <silent> [z <SID>setup_space("fold_start", "[z")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap zj
         silent! sunmap zk
         silent! sunmap ]z
@@ -258,7 +290,7 @@ endif
 if !exists("g:space_no_tags") || !g:space_no_tags
     noremap <expr> <silent> <C-]> <SID>setup_space("tag", "\<C-]>")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap <C-]>
     endif
 
@@ -272,7 +304,7 @@ if !exists("g:space_no_undolist") || !g:space_no_undolist
     noremap <expr> <silent> g- <SID>setup_space("undo", "g-")
     noremap <expr> <silent> g+ <SID>setup_space("undo", "g+")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap g-
         silent! sunmap g+
     endif
@@ -290,9 +322,9 @@ endif
 "       list to remove mappings.
 command! SpaceRemoveMappings call <SID>remove_space_mappings()
 function! s:remove_space_mappings()
-    silent! unmap <Space>
-    silent! unmap <S-Space>
-    silent! unmap <BS>
+    silent! unmap <Plug>SmartspaceNext
+    silent! unmap <Plug>SmartspacePrev
+    silent! unmap <Plug>SmartspacePrevnogui
 
     silent! unmap f
     silent! unmap F


### PR DESCRIPTION
"""
Allow user-defined mappings

Allow to replace &lt;Space&gt;, &lt;S-Space&gt; and &lt;BS&gt; individually. The defaults
stay the same.
Add an option to disable the "non-GUI" mapping (by default, &lt;BS&gt;).
Clean things a bit: now gives a proper message if a key is already mapped.
"""
