### PR TITLE
User-defined mappings, clean conf and new no_second_prev_mapping option

### DIFF
--- a/doc/space.txt
+++ b/doc/space.txt
@@ -16,21 +16,24 @@
 
                                                                  *space-toc*
 
-1. Intro                                               |space-intro|
-2. Usage                                               |space-usage|
-3. Hooks                                               |space-hooks|
-4. Status line integration                             |space-statusline|
-5. Configuration                                       |space-configuration|
-6. License                                             |space-license|
+1. Intro                                       |space-intro|
+2. Usage                                       |space-usage|
+3. Hooks                                       |space-hooks|
+4. Status line integration                     |space-statusline|
+5. Configuration                               |space-configuration|
+    5.1 Navigation group restriction                   |space-conf-navgroup|
+    5.2 Miscellaneous configuration                    |space-conf-misc|
+    5.3 User-defined mappings                          |space-conf-mapping|
+6. License                                     |space-license|
 
 
 
 ==============================================================================
 1. Intro                                                       *space-intro*
 
-space.vim is a plugin which remaps the *<Space>* key to act as a clever key
-to repeat motions. To disable space.vim, set the "space_loaded" global
-variable in your |vimrc| file: >
+space.vim is a plugin which remaps the *<Space>* key (or any other key, see
+|space-conf-mapping|) to act as a clever key to repeat motions. To disable
+space.vim, set the "space_loaded" global variable in your |vimrc| file: >
     :let g:space_loaded = 1
 
 space.vim hooks into several of the more complex motion commands, such as
@@ -201,6 +204,8 @@ status line using the GetSpaceMovement() function. Here's an example: >
 ==============================================================================
 5. Configuration                                       *space-configuration*
 
+5.1 Navigation group restriction                       *space-conf-navgroup*
+
 It is possible to avoid using the <Space> key for groups of navigation
 commands using global variables. For instance, you may wish to use <Space> to
 repeat the last command only for diff jumps and quickfix and location list
@@ -239,10 +244,37 @@ Disable <Space> for quickfix and location list commands >
 Disable <Space> for undolist movements >
     let g:space_no_undolist = 1
 
+5.2 Miscellaneous configuration                            *space-conf-misc*
+
 Furthermore it is possible to disable the hooks and mappings set by space.vim
 to affect the select mode (these can cause problems with some snippets plugins
 like snipmate.vim) >
     let g:space_disable_select_mode = 1
+
+5.1 User-defined mappings                               *space-conf-mapping*
+
+It is possible to use other keys than <Space>, <S-Space> and <BS> if you wish
+to. Just map other keys to the right <plug> references: >
+    <Plug>SmartspaceNext
+    <Plug>SmartspacePrev
+    <Plug>SmartspacePrevnogui
+
+For example, map <F1>/<S-F1> instead of <Space>/<S-Space> to jump to the
+next/previous item: >
+    nmap <unique> <F1> <Plug>SmartspaceNext
+    nmap <unique> <S-F1> <Plug>SmartspacePrev
+
+In a non-GUI, <S-F1> is not always available, so map <F2> to it instead: >
+    nmap <unique> <F2> <Plug>SmartspacePrevnogui
+
+
+Note: Be careful when choosing your mapping to not interfere with space.vim
+features. For example, by default, Vim maps <Tab> (or <C-i>) to "newer
+position in jump list", which is a motion that space.vim can repeat. If you
+want to use the <Tab> key with space.vim, you need to disable "space_jump" in
+space.vim (see |space-conf-navgroup| for the complete list). >
+    nmap <unique> <Tab> <Plug>SmartspacePrev
+    let g:space_no_jump = 1
 
 ==============================================================================
 6. License                                                   *space-license*

--- a/doc/space.txt
+++ b/doc/space.txt
@@ -251,6 +251,10 @@ to affect the select mode (these can cause problems with some snippets plugins
 like snipmate.vim) >
     let g:space_disable_select_mode = 1
 
+If you do not wish to use the <Plug>SmartspacePrevnongui mapping (and avoid
+having space.vim remap <BS>), use the following: >
+    let g:space_no_second_prev_mapping = 1
+
 5.1 User-defined mappings                               *space-conf-mapping*
 
 It is possible to use other keys than <Space>, <S-Space> and <BS> if you wish

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -91,6 +91,7 @@ if g:space_debug
     let g:space_no_tags = 0
     let g:space_no_foldopen = 0
     let g:space_disable_select_mode = 0
+    let g:space_no_second_prev_mapping = 0
     echomsg "Running space.vim in debug mode."
 elseif exists("g:space_loaded")
     finish
@@ -138,6 +139,10 @@ endif
 if !exists("g:space_no_foldopen")
     let g:space_no_foldopen = 0
 endif
+if !exists("g:space_no_second_prev_mapping")
+    let g:space_no_second_prev_mapping = 0
+endif
+
 
 " Mapping of <Space>/<S-Space> and possibly <BS>
 if !hasmapto('<Plug>SmartspaceNext')
@@ -163,12 +168,13 @@ if g:space_disable_select_mode
 endif
 
 " <BS> is only for console
-if !has("gui_running")
+if !has("gui_running") && !g:space_no_second_prev_mapping
     if !hasmapto('<Plug>SmartspacePrevnogui')
         if mapcheck("<BS>") == ""
             nmap <unique> <BS> <Plug>SmartspacePrevnogui
         else
-            echomsg "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui."
+            echomsg "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui"
+            echomsg "or add 'let g:space_no_second_prev_mapping = 1' in your conf to disable the mapping."
         endif
     endif
     noremap <expr> <silent> <Plug>SmartspacePrevnogui <SID>do_space(1, v:char)
@@ -176,7 +182,7 @@ if !has("gui_running")
     if g:space_disable_select_mode
         silent! sunmap <Plug>SmartspacePrevnogui
      endif
- endif
+endif
 
 
 " character movement commands

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -73,7 +73,11 @@
 " TODO: Make the mapping assignments more dynamical, and allow user defined
 "       commands?
 
-if exists("g:space_debug")
+" Debug mode: don't take user-defined options into acocunt
+if !exists("g:space_debug")
+    let g:space_debug = 0
+endif
+if g:space_debug
     let g:space_no_character_movements = 0
     let g:space_no_search = 0
     let g:space_no_jump = 0
@@ -85,17 +89,61 @@ if exists("g:space_debug")
     let g:space_no_quickfix = 0
     let g:space_no_undolist = 0
     let g:space_no_tags = 0
+    let g:space_no_foldopen = 0
+    let g:space_disable_select_mode = 0
     echomsg "Running space.vim in debug mode."
 elseif exists("g:space_loaded")
     finish
 endif
 let g:space_loaded = 1
 
+" Initialise default config vars values properly to avoid
+" using '!exists("g:space_foo") || !g:space_foo'
+if !exists("g:space_no_character_movements")
+    let g:space_no_character_movements = 0
+endif
+if !exists("g:space_no_search")
+    let g:space_no_search = 0
+endif
+if !exists("g:space_no_jump")
+    let g:space_no_jump = 0
+endif
+if !exists("g:space_no_diff")
+    let g:space_no_diff = 0
+endif
+if !exists("g:space_no_brace")
+    let g:space_no_brace = 0
+endif
+if !exists("g:space_no_method")
+    let g:space_no_method = 0
+endif
+if !exists("g:space_no_section")
+    let g:space_no_section = 0
+endif
+if !exists("g:space_no_folds")
+    let g:space_no_folds = 0
+endif
+if !exists("g:space_no_quickfix")
+    let g:space_no_quickfix = 0
+endif
+if !exists("g:space_no_undolist")
+    let g:space_no_undolist = 0
+endif
+if !exists("g:space_no_tags")
+    let g:space_no_tags = 0
+endif
+if !exists("g:space_disable_select_mode")
+    let g:space_disable_select_mode = 0
+endif
+if !exists("g:space_no_foldopen")
+    let g:space_no_foldopen = 0
+endif
+
 " Mapping of <Space>/<S-Space> and possibly <BS>
 noremap <expr> <silent> <Space>   <SID>do_space(0, "<Space>")
 noremap <expr> <silent> <S-Space> <SID>do_space(1, "<S-Space>")
 
-if exists("g:space_disable_select_mode")
+if g:space_disable_select_mode
     silent! sunmap <Space>
     silent! sunmap <S-Space>
     silent! sunmap <BS>
@@ -103,14 +151,14 @@ endif
 
 if mapcheck("<BS>") == "" || !has("gui_running")
     noremap <expr> <silent> <BS>      <SID>do_space(1, "<BS>")
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap <BS>
     endif
 endif
 
 
 " character movement commands
-if !exists("g:space_no_character_movements") || !g:space_no_character_movements
+if !g:space_no_character_movements
     noremap <expr> <silent> f <SID>setup_space("char", "f")
     noremap <expr> <silent> F <SID>setup_space("char", "F")
     noremap <expr> <silent> t <SID>setup_space("char", "t")
@@ -118,7 +166,7 @@ if !exists("g:space_no_character_movements") || !g:space_no_character_movements
     noremap <expr> <silent> ; <SID>setup_space("char", ";")
     noremap <expr> <silent> , <SID>setup_space("char", ",")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap f
         silent! sunmap F
         silent! sunmap t
@@ -129,7 +177,7 @@ if !exists("g:space_no_character_movements") || !g:space_no_character_movements
 endif
 
 " search commands
-if !exists("g:space_no_search") || !g:space_no_search
+if !g:space_no_search
 
     " do not override visual mappings for * and #
     " because these are often used for visual search functions
@@ -155,7 +203,7 @@ if !exists("g:space_no_search") || !g:space_no_search
     noremap <expr> <silent> n  <SID>setup_space("search", "n")
     noremap <expr> <silent> N  <SID>setup_space("search", "N")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap *
         silent! sunmap #
         silent! sunmap <kMultiply>
@@ -172,7 +220,7 @@ endif
 
 " jump commands
 " NOTE: Jumps are not motions. They can't be used in Visual mode.
-if !exists("g:space_no_jump") || !g:space_no_jump
+if !g:space_no_jump
     nnoremap <expr> <silent> g, <SID>setup_space("cjump", "g,")
     nnoremap <expr> <silent> g; <SID>setup_space("cjump", "g;")
     nnoremap <expr> <silent> <C-O> <SID>setup_space("jump", "\<C-o>")
@@ -180,25 +228,25 @@ if !exists("g:space_no_jump") || !g:space_no_jump
 endif
 
 " diff next/prev
-if !exists("g:space_no_diff") || !g:space_no_diff
+if !g:space_no_diff
     noremap <expr> <silent> ]c <SID>setup_space("diff", "]c")
     noremap <expr> <silent> [c <SID>setup_space("diff", "[c")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]c
         silent! sunmap [c
     endif
 endif
 
 " previous/next unmatched ( or [
-if !exists("g:space_no_brace") || !g:space_no_brace
+if !g:space_no_brace
     noremap <expr> <silent> ]) <SID>setup_space("paren", "])")
     noremap <expr> <silent> [( <SID>setup_space("paren", "[(")
 
     noremap <expr> <silent> ]} <SID>setup_space("curly", "]}")
     noremap <expr> <silent> [{ <SID>setup_space("curly", "[{")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ])
         silent! sunmap [(
         silent! sunmap ]}
@@ -207,14 +255,14 @@ if !exists("g:space_no_brace") || !g:space_no_brace
 endif
 
 " start/end of a method
-if !exists("g:space_no_method") || !g:space_no_method
+if !g:space_no_method
     noremap <expr> <silent> ]m <SID>setup_space("method_start", "]m")
     noremap <expr> <silent> [m <SID>setup_space("method_start", "[m")
 
     noremap <expr> <silent> ]M <SID>setup_space("method_end", "]M")
     noremap <expr> <silent> [M <SID>setup_space("method_end", "[M")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]m
         silent! sunmap [m
         silent! sunmap ]M
@@ -223,14 +271,14 @@ if !exists("g:space_no_method") || !g:space_no_method
 endif
 
 " previous/next section or '}'/'{' in the first column
-if !exists("g:space_no_section") || !g:space_no_section
+if !g:space_no_section
     noremap <expr> <silent> ]] <SID>setup_space("section_start", "]]")
     noremap <expr> <silent> [[ <SID>setup_space("section_start", "[[")
 
     noremap <expr> <silent> ][ <SID>setup_space("section_end", "][")
     noremap <expr> <silent> [] <SID>setup_space("section_end", "[]")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap ]]
         silent! sunmap [[
         silent! sunmap ][
@@ -239,14 +287,14 @@ if !exists("g:space_no_section") || !g:space_no_section
 endif
 
 " previous/next fold
-if !exists("g:space_no_folds") || !g:space_no_folds
+if !g:space_no_folds
     noremap <expr> <silent> zj <SID>setup_space("fold_next", "zj")
     noremap <expr> <silent> zk <SID>setup_space("fold_next", "zk")
 
     noremap <expr> <silent> ]z <SID>setup_space("fold_start", "]z")
     noremap <expr> <silent> [z <SID>setup_space("fold_start", "[z")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap zj
         silent! sunmap zk
         silent! sunmap ]z
@@ -255,10 +303,10 @@ if !exists("g:space_no_folds") || !g:space_no_folds
 endif
 
 " tag movement
-if !exists("g:space_no_tags") || !g:space_no_tags
+if !g:space_no_tags
     noremap <expr> <silent> <C-]> <SID>setup_space("tag", "\<C-]>")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap <C-]>
     endif
 
@@ -268,18 +316,18 @@ else
 endif
 
 " undolist movement
-if !exists("g:space_no_undolist") || !g:space_no_undolist
+if !g:space_no_undolist
     noremap <expr> <silent> g- <SID>setup_space("undo", "g-")
     noremap <expr> <silent> g+ <SID>setup_space("undo", "g+")
 
-    if exists("g:space_disable_select_mode")
+    if g:space_disable_select_mode
         silent! sunmap g-
         silent! sunmap g+
     endif
 endif
 
 " quickfix and location list commands
-if !exists("g:space_no_quickfix") || !g:space_no_quickfix
+if !g:space_no_quickfix
     cnoremap <expr> <CR> <SID>parse_cmd_line()
     let s:quickfix_mappings = 1
 else
@@ -546,7 +594,7 @@ function! s:do_space(shift, default)
 endfunc
 
 function! s:maybe_open_fold(cmd)
-    if !exists("g:space_no_foldopen") && &foldopen =~ s:cmd_type && v:operator != "c"
+    if !g:space_no_foldopen && &foldopen =~ s:cmd_type && v:operator != "c"
         " special treatment of :ex commands
         if s:cmd_type == "quickfix" || s:cmd_type == "tag"
             if getcmdtype() == ':'
@@ -584,7 +632,7 @@ function! s:maybe_open_fold(cmd)
 endfunc
 
 function! s:debug_msg(string)
-    if exists("g:space_debug")
+    if g:space_debug
         echomsg a:string
     endif
 endfunc

--- a/plugin/space.vim
+++ b/plugin/space.vim
@@ -140,21 +140,43 @@ if !exists("g:space_no_foldopen")
 endif
 
 " Mapping of <Space>/<S-Space> and possibly <BS>
-noremap <expr> <silent> <Space>   <SID>do_space(0, "<Space>")
-noremap <expr> <silent> <S-Space> <SID>do_space(1, "<S-Space>")
-
-if g:space_disable_select_mode
-    silent! sunmap <Space>
-    silent! sunmap <S-Space>
-    silent! sunmap <BS>
-endif
-
-if mapcheck("<BS>") == "" || !has("gui_running")
-    noremap <expr> <silent> <BS>      <SID>do_space(1, "<BS>")
-    if g:space_disable_select_mode
-        silent! sunmap <BS>
+if !hasmapto('<Plug>SmartspaceNext')
+    if mapcheck("<Space>") == ""
+        nmap <unique> <Space> <Plug>SmartspaceNext
+    else
+        echomsg "space.vim: <Space> key already mapped. Please map another key to <Plug>SmartspaceNext."
     endif
 endif
+if !hasmapto('<Plug>SmartspacePrev')
+    if mapcheck("<S-Space>") == ""
+        nmap <unique> <S-Space> <Plug>SmartspacePrev
+    else
+        echomsg "space.vim: <S-Space> key already mapped. Please map another key to <Plug>SmartspacePrev."
+    endif
+endif
+noremap <script> <expr> <silent> <Plug>SmartspaceNext <SID>do_space(0, v:char)
+noremap <script> <expr> <silent> <Plug>SmartspacePrev <SID>do_space(1, v:char)
+
+if g:space_disable_select_mode
+    silent! sunmap <Plug>SmartspaceNext
+    silent! sunmap <Plug>SmartspacePrev
+endif
+
+" <BS> is only for console
+if !has("gui_running")
+    if !hasmapto('<Plug>SmartspacePrevnogui')
+        if mapcheck("<BS>") == ""
+            nmap <unique> <BS> <Plug>SmartspacePrevnogui
+        else
+            echomsg "space.vim: <BS> key already mapped. Please map another key to <Plug>SmartspacePrevnogui."
+        endif
+    endif
+    noremap <expr> <silent> <Plug>SmartspacePrevnogui <SID>do_space(1, v:char)
+
+    if g:space_disable_select_mode
+        silent! sunmap <Plug>SmartspacePrevnogui
+     endif
+ endif
 
 
 " character movement commands
@@ -338,9 +360,9 @@ endif
 "       list to remove mappings.
 command! SpaceRemoveMappings call <SID>remove_space_mappings()
 function! s:remove_space_mappings()
-    silent! unmap <Space>
-    silent! unmap <S-Space>
-    silent! unmap <BS>
+    silent! unmap <Plug>SmartspaceNext
+    silent! unmap <Plug>SmartspacePrev
+    silent! unmap <Plug>SmartspacePrevnogui
 
     silent! unmap f
     silent! unmap F


### PR DESCRIPTION
This pull request contains 3 bits:
- one to normalise the conf options (ie define all the defaults at the beginning and stop using "exists" to test the setting)
- one to let users choose the mapping they want instead of &lt;space&gt;, &lt;s-space&gt; and &lt;bs&gt;
- one to add a "don't create a nogui mapping" (the one that defaults to &lt;bs&gt;)
